### PR TITLE
Feature/9

### DIFF
--- a/src/common/exceptions/exception.ts
+++ b/src/common/exceptions/exception.ts
@@ -1,0 +1,9 @@
+interface Exception {
+  name: string;
+  message: string;
+}
+
+export class EntityNotFoundException implements Exception {
+  public readonly name: 'EntityNotFoundException';
+  public readonly message: 'entity not found';
+}

--- a/src/common/interceptors/http.interceptor.ts
+++ b/src/common/interceptors/http.interceptor.ts
@@ -1,0 +1,29 @@
+import {
+  CallHandler,
+  ExecutionContext,
+  Injectable,
+  NestInterceptor,
+  NotFoundException,
+} from '@nestjs/common';
+import { catchError, Observable } from 'rxjs';
+import { EntityNotFoundException } from '../exceptions/exception';
+
+@Injectable()
+export class NotFoundInterceptor implements NestInterceptor {
+  constructor(private errorMessage: string) {}
+
+  intercept(
+    context: ExecutionContext,
+    next: CallHandler<any>,
+  ): Observable<any> | Promise<Observable<any>> {
+    return next.handle().pipe(
+      catchError((error) => {
+        if (error instanceof EntityNotFoundException) {
+          throw new NotFoundException(this.errorMessage);
+        } else {
+          throw error;
+        }
+      }),
+    );
+  }
+}

--- a/src/common/middlewares/PagerMiddleware.ts
+++ b/src/common/middlewares/PagerMiddleware.ts
@@ -1,0 +1,11 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+
+@Injectable()
+export class PagerMiddleware implements NestMiddleware {
+  use(req: any, res: any, next: () => void) {
+    if (!+req.query.page || req.query.page <= 0) {
+      req.query.page = 1;
+    }
+    next();
+  }
+}

--- a/src/posts/posts.controller.ts
+++ b/src/posts/posts.controller.ts
@@ -6,10 +6,13 @@ import {
   Patch,
   Param,
   Delete,
+  Query,
+  UseInterceptors,
 } from '@nestjs/common';
 import { PostsService } from './posts.service';
 import { CreatePostDto } from './dto/create-post.dto';
 import { UpdatePostDto } from './dto/update-post.dto';
+import { NotFoundInterceptor } from '../common/interceptors/http.interceptor';
 
 @Controller('posts')
 export class PostsController {
@@ -21,11 +24,14 @@ export class PostsController {
   }
 
   @Get()
-  findAll() {
-    return this.postsService.findAll();
+  findAll(@Query() { page }) {
+    return this.postsService.findAll(page);
   }
 
   @Get(':id')
+  @UseInterceptors(
+    new NotFoundInterceptor(`The requested URL was not found on this server.`),
+  )
   findOne(@Param('id') id: string) {
     return this.postsService.findOne(+id);
   }
@@ -36,6 +42,9 @@ export class PostsController {
   }
 
   @Delete(':id')
+  @UseInterceptors(
+    new NotFoundInterceptor('The requested URL was not found on this server.'),
+  )
   delete(@Param('id') id: string, @Body('password') password: string) {
     return this.postsService.delete(+id, password);
   }

--- a/src/posts/posts.module.ts
+++ b/src/posts/posts.module.ts
@@ -1,12 +1,24 @@
-import { Module } from '@nestjs/common';
+import {
+  MiddlewareConsumer,
+  Module,
+  NestModule,
+  RequestMethod,
+} from '@nestjs/common';
 import { PostsService } from './posts.service';
 import { PostsController } from './posts.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { PostEntity } from './entities/post.entity';
+import { PagerMiddleware } from '../common/middlewares/PagerMiddleware';
 
 @Module({
   controllers: [PostsController],
   providers: [PostsService],
   imports: [TypeOrmModule.forFeature([PostEntity])],
 })
-export class PostsModule {}
+export class PostsModule implements NestModule {
+  configure(consumer: MiddlewareConsumer): any {
+    consumer
+      .apply(PagerMiddleware)
+      .forRoutes({ path: 'posts', method: RequestMethod.GET });
+  }
+}


### PR DESCRIPTION
## feat: 게시글 조회 기능 구현 (GET: /posts)
- 게시글 id와 게시글 제목만 노출
- 최신 글 순서로 정렬
- 페이지네이션(추가 로드는 20 개 단위)
  - page, pageSize(20) 설정으로 프론트 개발자가 스크롤에 따른 요청을 보낼 때마다 ++page되며 20개씩 게시글 리스트 반환
  - middleware를 통해서 값이 없거나 유효하지 않은 경우 page 1로 default 값 설정 후 service 로직 호출

## feat: 게시글 조회 기능 구현 (GET: /posts/:id)
- 패스워드를 제외한 게시글 정보(id, 제목, 내용, 생성일자, 수정일자) 모두 노출

## refactor: 인터셉터를 통한 HTTP Error 핸들링
- Entity가 존재하지 않는 경우, http 에러를 서비스 로직에서 날리는 것이 맞는가?
- single responsibility principle을 위반했다고 판단하고, service 로직에서 EntityNotFoundException(custom) 에러를 던지면, controller에 붙어있는 interceptor 데코레이터에서 인식 후 NotFoundError로 변환해 에러를 표시한다.
- 이렇게 함으로써, 책임과 역할을 더 잘 분리해서 에러를 핸들링할 수 있다.