### PR TITLE
feat: weather 모듈 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@faker-js/faker": "^7.5.0",
+        "@nestjs/axios": "^0.1.0",
         "@nestjs/common": "^9.0.1",
         "@nestjs/core": "^9.0.1",
         "@nestjs/mapped-types": "*",
@@ -1457,6 +1458,19 @@
         "node-pre-gyp": "bin/node-pre-gyp"
       }
     },
+    "node_modules/@nestjs/axios": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-0.1.0.tgz",
+      "integrity": "sha512-b2TT2X6BFbnNoeteiaxCIiHaFcSbVW+S5yygYqiIq5i6H77yIU3IVuLdpQkHq8/EqOWFwMopLN8jdkUT71Am9w==",
+      "dependencies": {
+        "axios": "0.27.2"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0",
+        "reflect-metadata": "^0.1.12",
+        "rxjs": "^6.0.0 || ^7.0.0"
+      }
+    },
     "node_modules/@nestjs/cli": {
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-9.1.2.tgz",
@@ -2654,8 +2668,16 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "dependencies": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
     },
     "node_modules/babel-jest": {
       "version": "28.1.3",
@@ -3304,7 +3326,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -3524,7 +3545,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -4348,6 +4368,25 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fork-ts-checker-webpack-plugin": {
       "version": "7.2.13",
       "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-7.2.13.tgz",
@@ -4402,7 +4441,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -10189,6 +10227,14 @@
         "tar": "^6.1.11"
       }
     },
+    "@nestjs/axios": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/axios/-/axios-0.1.0.tgz",
+      "integrity": "sha512-b2TT2X6BFbnNoeteiaxCIiHaFcSbVW+S5yygYqiIq5i6H77yIU3IVuLdpQkHq8/EqOWFwMopLN8jdkUT71Am9w==",
+      "requires": {
+        "axios": "0.27.2"
+      }
+    },
     "@nestjs/cli": {
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/@nestjs/cli/-/cli-9.1.2.tgz",
@@ -11107,8 +11153,16 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "dev": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+    },
+    "axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
+      "requires": {
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
     },
     "babel-jest": {
       "version": "28.1.3",
@@ -11577,7 +11631,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -11753,8 +11806,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "dev": true
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ=="
     },
     "delegates": {
       "version": "1.0.0",
@@ -12389,6 +12441,11 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
     },
+    "follow-redirects": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA=="
+    },
     "fork-ts-checker-webpack-plugin": {
       "version": "7.2.13",
       "resolved": "https://registry.npmjs.org/fork-ts-checker-webpack-plugin/-/fork-ts-checker-webpack-plugin-7.2.13.tgz",
@@ -12425,7 +12482,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dev": true,
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "dependencies": {
     "@faker-js/faker": "^7.5.0",
+    "@nestjs/axios": "^0.1.0",
     "@nestjs/common": "^9.0.1",
     "@nestjs/core": "^9.0.1",
     "@nestjs/mapped-types": "*",

--- a/src/common/middlewares/posts.middleware.ts
+++ b/src/common/middlewares/posts.middleware.ts
@@ -1,4 +1,7 @@
 import { Injectable, NestMiddleware } from '@nestjs/common';
+import { HttpService } from '@nestjs/axios';
+import { firstValueFrom } from 'rxjs';
+import { WEATHER_URL } from '../../environments';
 
 @Injectable()
 export class PagerMiddleware implements NestMiddleware {
@@ -6,6 +9,19 @@ export class PagerMiddleware implements NestMiddleware {
     if (!+req.query.page || req.query.page <= 0) {
       req.query.page = 1;
     }
+    next();
+  }
+}
+
+@Injectable()
+export class WeatherInsertMiddleware implements NestMiddleware {
+  constructor(private httpService: HttpService) {}
+
+  async use(req: any, res: any, next: (error?: any) => void): Promise<any> {
+    const { data } = await firstValueFrom(this.httpService.get(WEATHER_URL));
+
+    req.body.weather = data.current.condition.text;
+
     next();
   }
 }

--- a/src/config/typeorm/index.ts
+++ b/src/config/typeorm/index.ts
@@ -9,7 +9,6 @@ export class TypeormService implements TypeOrmOptionsFactory {
     return {
       ...TYPEORM,
       entities: [__dirname + '/../../**/**/*.entity{.ts,.js}'],
-      // synchronize: true,
       logging: true,
     };
   }

--- a/src/database/data-source.ts
+++ b/src/database/data-source.ts
@@ -9,6 +9,7 @@ import { SeederOptions } from 'typeorm-extension';
 
 const options: DataSourceOptions & SeederOptions = {
   ...TYPEORM,
+  synchronize: true,
   entities: [PostEntity],
   seeds: [TYPEORM_SEEDING_SEEDS],
   factories: [TYPEORM_SEEDING_FACTORIES],

--- a/src/database/factories/posts/create-posts.factory.ts
+++ b/src/database/factories/posts/create-posts.factory.ts
@@ -1,15 +1,19 @@
 import { setSeederFactory } from 'typeorm-extension';
 import * as bcrypt from 'bcrypt';
-import { BCRYPT_SALT } from '../../../environments';
+import { BCRYPT_SALT, WEATHER_URL } from '../../../environments';
 import { PostEntity } from '../../../posts/entities/post.entity';
+import { HttpService } from '@nestjs/axios';
+import { firstValueFrom } from 'rxjs';
 
 export default setSeederFactory(PostEntity, async (faker) => {
   const post = new PostEntity();
-  1;
+  const httpService = new HttpService();
+  const { data } = await firstValueFrom(httpService.get(WEATHER_URL));
 
   post.title = faker.internet.emoji() + faker.name.jobType();
   post.content = faker.internet.emoji() + faker.lorem.sentence();
   post.password = await bcrypt.hash(faker.internet.password(), BCRYPT_SALT);
+  post.weather = data.current.condition.text;
 
   return post;
 });

--- a/src/environments/index.ts
+++ b/src/environments/index.ts
@@ -46,9 +46,16 @@ const TYPEORM = environment[NODE_ENV];
 const TYPEORM_SEEDING_SEEDS = env.TYPEORM_SEEDING_SEEDS;
 const TYPEORM_SEEDING_FACTORIES = env.TYPEORM_SEEDING_FACTORIES;
 
+// Weather API
+const key = env.WEATHER_API_KEY;
+const city = 'Seoul';
+const lang = 'ko';
+const WEATHER_URL = `http://api.weatherapi.com/v1/current.json?key=${key}&q=${city}&lang=${lang}`;
+
 export {
   TYPEORM,
   BCRYPT_SALT,
   TYPEORM_SEEDING_SEEDS,
   TYPEORM_SEEDING_FACTORIES,
+  WEATHER_URL,
 };

--- a/src/posts/dto/create-post.dto.ts
+++ b/src/posts/dto/create-post.dto.ts
@@ -1,4 +1,4 @@
-import { IsNotEmpty, IsString, Matches, MaxLength } from 'class-validator';
+import { IsNotEmpty, IsString, Matches } from 'class-validator';
 import { PostDto } from './post.dto';
 
 export class CreatePostDto extends PostDto {
@@ -8,4 +8,8 @@ export class CreatePostDto extends PostDto {
       'password must be longer than 6 characters and contain at least 1 number',
   })
   password: string;
+
+  @IsString()
+  @IsNotEmpty()
+  readonly weather: string;
 }

--- a/src/posts/entities/post.entity.ts
+++ b/src/posts/entities/post.entity.ts
@@ -24,8 +24,8 @@ export class PostEntity {
    * @todo weather api 사용시 필드 주석 해제하기
    * @type {string}
    * */
-  //  @Column({ nullable: false })
-  //  weather: string;
+  @Column({ nullable: false })
+  weather: string;
 
   @CreateDateColumn({
     type: 'timestamp',

--- a/src/posts/posts.module.ts
+++ b/src/posts/posts.module.ts
@@ -4,21 +4,28 @@ import {
   NestModule,
   RequestMethod,
 } from '@nestjs/common';
-import { PostsService } from './posts.service';
-import { PostsController } from './posts.controller';
 import { TypeOrmModule } from '@nestjs/typeorm';
+import {
+  PagerMiddleware,
+  WeatherInsertMiddleware,
+} from '../common/middlewares/posts.middleware';
+import { HttpModule } from '@nestjs/axios';
+import { PostsController } from './posts.controller';
+import { PostsService } from './posts.service';
 import { PostEntity } from './entities/post.entity';
-import { PagerMiddleware } from '../common/middlewares/posts.middleware';
 
 @Module({
   controllers: [PostsController],
   providers: [PostsService],
-  imports: [TypeOrmModule.forFeature([PostEntity])],
+  imports: [TypeOrmModule.forFeature([PostEntity]), HttpModule],
 })
 export class PostsModule implements NestModule {
   configure(consumer: MiddlewareConsumer): any {
     consumer
       .apply(PagerMiddleware)
       .forRoutes({ path: 'posts', method: RequestMethod.GET });
+    consumer
+      .apply(WeatherInsertMiddleware)
+      .forRoutes({ path: 'posts', method: RequestMethod.POST });
   }
 }

--- a/src/posts/posts.service.ts
+++ b/src/posts/posts.service.ts
@@ -1,20 +1,16 @@
 import * as bcrypt from 'bcrypt';
-import {
-  ForbiddenException,
-  Injectable,
-  NotFoundException,
-} from '@nestjs/common';
+import { Repository } from 'typeorm';
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { BCRYPT_SALT } from '../environments';
+import { PostEntity } from './entities/post.entity';
 import { CreatePostDto } from './dto/create-post.dto';
 import { UpdatePostDto } from './dto/update-post.dto';
-import { InjectRepository } from '@nestjs/typeorm';
-import { PostEntity } from './entities/post.entity';
-import { Repository } from 'typeorm';
-import { BCRYPT_SALT } from '../environments';
+
 import {
   EntityNotFoundException,
   IncorrectPasswordException,
 } from '../common/exceptions/exception';
-import { PostDto } from './dto/post.dto';
 
 @Injectable()
 export class PostsService {
@@ -28,6 +24,8 @@ export class PostsService {
   ): Promise<CreatePostDto | undefined> {
     await this.transformPassword(createPostDto);
 
+    console.log(createPostDto);
+
     return await this.postsRepository.save(createPostDto);
   }
 
@@ -38,6 +36,7 @@ export class PostsService {
       .createQueryBuilder('posts')
       .select('posts.id')
       .addSelect('posts.title')
+      .addSelect('posts.weather')
       .take(take)
       .skip(take * (page - 1))
       .getMany();
@@ -49,6 +48,7 @@ export class PostsService {
       .select('posts.id')
       .addSelect('posts.title')
       .addSelect('posts.content')
+      .addSelect('posts.weather')
       .addSelect('posts.created_at')
       .addSelect('posts.updated_at')
       .where('posts.id = :id', { id: id })


### PR DESCRIPTION
## feat: weather 모듈 추가
- 외부 API 를 활용하여, 사용자가 게시글을 업로드한 시점의 날씨(예: 맑음, 흐림, 소나기, 눈 등) 정보가 게시글에 포함되도록 해야한다.
- 게시글 작성 시 자동으로 데이터베이스에 추가되고, 수정은 불가하다.
- 미들웨어에서 weatherAPI 날씨 데이터 호출 후 req.body.weather에 실어서 POST /posts 에 전달
- UpdatePostDto는 PartialType으로 PostDto를 상속 받는데, PostDto는 weather 필드가 없어서 날씨는 수정이 불가능한 구조